### PR TITLE
Update menu layout for gradient orientation and color picker

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -367,6 +367,7 @@ struct MaterialsView: View {
                             .padding()
                             .background(.ultraThinMaterial)
                             .clipShape(Circle())
+                            .frame(width: 50, height: 50) // Confining to a square layout
                     }
                 }
                 .padding()
@@ -381,6 +382,7 @@ struct MaterialsView: View {
                     .padding()
                     .background(.ultraThinMaterial)
                     .cornerRadius(12)
+                    .position(x: 100, y: 100) // Fixed position near the eyedropper button
                 }
                 
                 Spacer()


### PR DESCRIPTION
Update the gradient orientation menu layout and color picker menu position.

* Confining the gradient orientation menu to a square layout.
* Positioning the gradient orientation menu below the play/pause button and color picker.
* Setting the color picker menu to open near the eyedropper button in a fixed position at the right side of it.

